### PR TITLE
Instructions and missing classes for bio_gpt_large

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,30 @@ generate = m.generate([src_tokens], beam=args.beam)[0]
 output = m.decode(generate[0]["tokens"])
 print(output)
 ```
+Use fine-tuned BioGPT-Large model on PubMedQA in your code:
+
+First run `examples/QA-PubMedQA/preprocess_large.sh`
+
+```python
+import torch
+from fairseq.models.transformer_lm import TransformerLanguageModel
+m = TransformerLanguageModel.from_pretrained(
+        "checkpoints/QA-PubMedQA-BioGPT-Large", 
+        "checkpoint_avg.pt", 
+        "data/PubMedQA/biogpt-large-ansis-bin",
+        tokenizer='moses', 
+        bpe='fastbpe', 
+        bpe_codes="data/biogpt_large_bpecodes",
+        min_len=100,
+        max_len_b=1024
+)
+m.cuda()
+src_text="" # input text, e.g., a PubMed abstract
+src_tokens = m.encode(src_text)
+generate = m.generate([src_tokens], beam=1)[0]
+output = m.decode(generate[0]["tokens"])
+print(output)
+```
 
 For more downstream tasks, please see below.
 

--- a/src/transformer_lm_prompt.py
+++ b/src/transformer_lm_prompt.py
@@ -78,10 +78,15 @@ class TransformerLanguageModelPrompt(TransformerLanguageModel):
         return super().load_state_dict(new_state_dict, strict)
 
 
+@register_model("transformer_lm_prompt_spt", dataclass=TransformerLanguageModelConfig)
+class TransformerLanguageModelPromptSPT(TransformerLanguageModelPrompt):
+    """BioGPT-Large and BioGPT have the same logic?"""
+
+
 @register_model_architecture("transformer_lm_prompt", "transformer_lm_prompt_biogpt")
 def transformer_lm_prompt_biogpt(args):
     transformer_lm_gpt2_small(args)
 
-@register_model_architecture("transformer_lm_prompt", "transformer_lm_prompt_biogpt_large")
+@register_model_architecture("transformer_lm_prompt_spt", "transformer_lm_prompt_biogpt_large")
 def transformer_lm_prompt_gpt2_big(args):
     transformer_lm_gpt2_big(args)


### PR DESCRIPTION
Dear authors, thank you for releasing your code and models, very impressive results!

I was running BioGPT-Large and it looks like there is some missing code. Adding `transformer_lm_prompt_spt` which appears to be missing and to check is the implementation the same as the base model?