### PR TITLE
Delete `pip install fastBPE` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ export MOSES=${PWD}/mosesdecoder
 ```
 * fastBPE
 ``` bash
-pip install fastBPE
 git clone https://github.com/glample/fastBPE.git
 export FASTBPE=${PWD}/fastBPE
 cd fastBPE


### PR DESCRIPTION
Thank you for providing great code as an oss project. There is one suggestion because I got an error when I set up BioGPT.

```bash
 $ pip install fastBPE

Collecting fastBPE
  Downloading fastBPE-0.1.0.tar.gz (35 kB)
  Preparing metadata (setup.py) ... done
Building wheels for collected packages: fastBPE
  Building wheel for fastBPE (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
  ╰─> [212 lines of output]
      running bdist_wheel
      running build
      running build_py
      warning: build_py: byte-compiling is disabled, skipping.

      running build_ext
      building 'fastBPE' extension
      creating build
      creating build/temp.macosx-12.6-arm64-cpython-310
      creating build/temp.macosx-12.6-arm64-cpython-310/fastBPE
      clang -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -I/Users/yuta519/.local/share/virtualenvs/bio-c43PJldc/include -I/Users/yuta519/.pyenv/versions/3.10.6/include/python3.10 -c fastBPE/fastBPE.cpp -o build/temp.macosx-12.6-arm64-cpython-310/fastBPE/fastBPE.o -std=c++11 -Ofast -pthread
      In file included from fastBPE/fastBPE.cpp:610:
      fastBPE/fastBPE.hpp:84:68: warning: format specifies type 'unsigned long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Wformat]
        fprintf(stderr, "Read %lu words (%lu unique) from text file.\n", total,
                              ~~~                                        ^~~~~
                              %llu
　
   ...
```

From [fastBPE README](https://github.com/glample/fastBPE#installation), I thought `pip install fastBPE` is not necessary.